### PR TITLE
Feat: Remove deprecated query

### DIFF
--- a/src/main/java/io/moderne/organizations/DgsConstants.java
+++ b/src/main/java/io/moderne/organizations/DgsConstants.java
@@ -8,17 +8,11 @@ public class DgsConstants {
   public static class QUERY {
     public static final String TYPE_NAME = "Query";
 
-    public static final String Organizations = "organizations";
-
     public static final String AllOrganizations = "allOrganizations";
 
     public static final String UserOrganizations = "userOrganizations";
 
     public static final String Organization = "organization";
-
-    public static class ORGANIZATIONS_INPUT_ARGUMENT {
-      public static final String Repository = "repository";
-    }
 
     public static class USERORGANIZATIONS_INPUT_ARGUMENT {
       public static final String User = "user";

--- a/src/main/java/io/moderne/organizations/OrganizationDataFetcher.java
+++ b/src/main/java/io/moderne/organizations/OrganizationDataFetcher.java
@@ -36,14 +36,6 @@ public class OrganizationDataFetcher {
                 .map(this::mapOrganization);
     }
 
-    @Deprecated
-    @DgsQuery
-    Flux<Organization> organizations(@InputArgument RepositoryInput repository) {
-        return Flux.fromIterable(organizations.values())
-                .filter(org -> org.repositories().contains(repository))
-                .map(this::mapOrganization);
-    }
-
     @DgsQuery
     Flux<Organization> userOrganizations(@InputArgument User user, @InputArgument OffsetDateTime at) {
         // everybody belongs to every organization, and the "default" organization is listed

--- a/src/main/resources/schema/moderne-organizations.graphqls
+++ b/src/main/resources/schema/moderne-organizations.graphqls
@@ -1,11 +1,5 @@
 type Query {
     """
-    Deprecated: will be replaced by allOrganizations query.
-    The list of organizations that a repository belongs to.
-    """
-    organizations(repository: RepositoryInput!): [Organization!]! @deprecated(reason: "Will be replaced by allOrganizations query.")
-
-    """
     The list of all possible organizations
     """
     allOrganizations: [Organization!]!


### PR DESCRIPTION
Remove the deprecated `organizations(repositoryInput)` from organizations v2 template